### PR TITLE
improve: AppColor()

### DIFF
--- a/tsutaeru/lib/init_process.dart
+++ b/tsutaeru/lib/init_process.dart
@@ -53,8 +53,8 @@ Future<void> initProcess() async {
 Future<Color> insertDefaultColor() async {
   Color defaultColor = Color();
   defaultColor.id = "default_color";
-  defaultColor.textColor = defaultTextColor;
-  defaultColor.backgroundColor = defaultBackgroungColor;
+  defaultColor.textColor = AppColor.defaultTextColor;
+  defaultColor.backgroundColor = AppColor.defaultBackgroungColor;
   defaultColor.create();
 
   return defaultColor;

--- a/tsutaeru/lib/values/colors.dart
+++ b/tsutaeru/lib/values/colors.dart
@@ -1,4 +1,6 @@
-const primaryColor = 0x04bf9dff;
-const secondaryColor = 0xf5841bff;
-const defaultTextColor = 0x505050ff;
-const defaultBackgroungColor = 0xfafafaff;
+class AppColor {
+  static const primaryColor = 0x04bf9dff;
+  static const secondaryColor = 0xf5841bff;
+  static const defaultTextColor = 0x505050ff;
+  static const defaultBackgroungColor = 0xfafafaff;
+}

--- a/tsutaeru/lib/widgets/group_list.dart
+++ b/tsutaeru/lib/widgets/group_list.dart
@@ -41,7 +41,8 @@ class _GroupListState extends State<GroupList> {
   Widget build(BuildContext context) {
     return MaterialApp(
         theme: ThemeData(
-            appBarTheme: const AppBarTheme(color: Color(primaryColor))),
+            appBarTheme:
+                const AppBarTheme(color: Color(AppColor.primaryColor))),
         home: Scaffold(
           appBar: AppBar(
             title: const Text(AppString.appName),


### PR DESCRIPTION
**Pull Request**
`tsutaeru/lib/values/colors.dart`のデータ構造を変更し、実装しました。今までは`colors.dart`内の変数を次のように使用していました。
```
import 'package:tsutaeru/values/colors.dart';
// 省略
defaultColor.textColor = defaultTextColor;
```
変数名の重複を避けるためこれからは次のように使用できます。
```
import 'package:tsutaeru/values/colors.dart';
// 省略
defaultColor.textColor = AppColor.defaultTextColor;
```